### PR TITLE
fix search results not displayed when exiting lock screen with this t…

### DIFF
--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -1680,6 +1680,7 @@ StScrollBar {
 #searchResultsBin { max-width: 1000px; }
 
 #searchResultsContent {
+  max-width: 1000px;
   padding-left: 20px;
   padding-right: 20px;
   spacing: 16px;


### PR DESCRIPTION
…heme

This fixes #274 

As you can see in gnome-shell classic theme, they add the `max-width` directive to the `#searchResultsContent` selector in gnome 3.34 : 

https://gitlab.gnome.org/GNOME/gnome-shell/blob/gnome-3-34/data/theme/gnome-shell-sass/_common.scss#L1392

I don't see it in gnome 3.32 :

https://gitlab.gnome.org/GNOME/gnome-shell/blob/gnome-3-32/data/theme/gnome-shell-sass/_common.scss#L1392

However it should not be an issue to add it if you look at this : 

https://gitlab.gnome.org/GNOME/gnome-shell/blob/gnome-3-32/js/ui/search.js#L381

we see that `searchResultsBin` is a child layout of `searchResultsContent`.

This is the PR that introduces this change in gnome-shell : https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/110

