### PR TITLE
Use non-deprecated options for inkscape

### DIFF
--- a/common/gtk-2.0/Makefile.am
+++ b/common/gtk-2.0/Makefile.am
@@ -45,7 +45,7 @@ endif
 else
 
 $(light) $(dark):
-	$(INKSCAPE) --export-id-only --export-png="$@" --export-id="$(basename $(notdir $@))" --export-dpi=$(if $(filter $(OPTION_GTK2_HIDPI),true),192,96) "$<" >/dev/null
+	$(INKSCAPE) --export-id-only --export-type="png" --export-file="$@" --export-id="$(basename $(notdir $@))" --export-dpi=$(if $(filter $(OPTION_GTK2_HIDPI),true),192,96) "$<" >/dev/null
 if OPTIPNG
 	$(OPTIPNG) -o7 --quiet "$@"
 endif

--- a/common/gtk-3.0/common.am
+++ b/common/gtk-3.0/common.am
@@ -30,12 +30,12 @@ endif
 else
 
 $(normal): $(srcdir)/assets.svg | assets
-	$(INKSCAPE) --export-id-only --export-png="$@" --export-id="$(basename $(notdir $@))" --export-dpi=96 "$<" >/dev/null
+	$(INKSCAPE) --export-id-only --export-type="png" --export-file="$@" --export-id="$(basename $(notdir $@))" --export-dpi=96 "$<" >/dev/null
 if OPTIPNG
 	$(OPTIPNG) -o7 --quiet "$@"
 endif
 $(hidpi): $(srcdir)/assets.svg | assets
-	$(INKSCAPE) --export-id-only --export-png="$@" --export-id="$(patsubst %@2,%,$(basename $(notdir $@)))" --export-dpi=192 "$<" >/dev/null
+	$(INKSCAPE) --export-id-only --export-type="png" --export-file="$@" --export-id="$(patsubst %@2,%,$(basename $(notdir $@)))" --export-dpi=192 "$<" >/dev/null
 if OPTIPNG
 	$(OPTIPNG) -o7 --quiet "$@"
 endif

--- a/common/xfwm4/Makefile.am
+++ b/common/xfwm4/Makefile.am
@@ -27,7 +27,7 @@ endif
 else
 
 $(light) $(dark):
-	$(INKSCAPE) --export-id-only --export-png="$@" --export-id="$(basename $(notdir $@))" --export-dpi=$(if $(filter $(OPTION_GTK2_HIDPI),true),192,96) "$<" >/dev/null
+	$(INKSCAPE) --export-id-only --export-type="png" --export-file="$@" --export-id="$(basename $(notdir $@))" --export-dpi=$(if $(filter $(OPTION_GTK2_HIDPI),true),192,96) "$<" >/dev/null
 if OPTIPNG
 	$(OPTIPNG) -o7 --quiet "$@"
 endif


### PR DESCRIPTION
The `--export-png` option has been deprecated in recent versions of inkscape. Instead, the same functionality must be achieved by using the `--export-type` and the `--export-file` options together.